### PR TITLE
Updated data according to Traficar pricing changes on 02.01.2025

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -5,11 +5,11 @@
       "Operator": "Traficar",
       "Grupa": "Traficar",
       "start": 4.99,
-      "km": 2.09,
+      "km": 1.69,
       "km_free": 0,
       "minuty_free": 0,
       "min_jazdy": 0,
-      "min_postoj": 0.30,
+      "min_postoj": 0.29,
       "miasta": [
         "Kraków",
         "Warszawa",
@@ -59,7 +59,7 @@
       "km_free": 0,
       "minuty_free": 0,
       "min_jazdy": 0,
-      "min_postoj": 0.30,
+      "min_postoj": 0.29,
       "miasta": [
         "Kraków",
         "Warszawa",

--- a/public/index.html
+++ b/public/index.html
@@ -101,7 +101,7 @@
         <div class="form">
             <div id="form_placeholder"></div>
         </div>
-        <p><b>Wyliczenia wg. cen na dzień 29 października 2024.</b></p>
+        <p><b>Wyliczenia wg. cen na dzień 02 stycznia 2025.</b></p>
     </div>
 
     <footer class="container my-2 mb-3 pt-2 text-body-secondary text-small">


### PR DESCRIPTION
Pricing data was pulled from the API, the website does not show the correct pricing for stopped time according to today's pricing changes (0.3 PLN on the site vs 0.29 PLN in the API)